### PR TITLE
feat: add Docker data-root migration feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,15 @@ terraform fmt
 
 # Plan changes (apply is forbidden)
 terraform plan
+
+# Create tfmigrate file for importing existing resources
+touch tfmigrate/$(date "+%Y%m%d%H%M%S")_{migrate_name}.hcl
 ```
 
 ### Ansible Commands
 ```bash
-# Lint all Ansible code
-ansible-lint .
+# Lint all Ansible code (run from ansible/ directory)
+cd ansible && ansible-lint .
 
 # Check playbook execution (dry-run only)
 ansible-playbook --check --diff -i inventories/[inventory_name]/hosts [playbook].yml
@@ -40,26 +43,28 @@ ansible-playbook --check --diff -i inventories/[inventory_name]/hosts [playbook]
 # Examples:
 ansible-playbook --check --diff -i inventories/develop_ubuntu/hosts site.yml --limit 127.0.0.1 --connection local
 ansible-playbook --check --diff -i inventories/homeserver/hosts site.yml --limit home
+ansible-playbook --check --diff -i inventories/oci-tokyo-ampere/hosts oci-tokyo-ampere.yml
 ```
 
 ## Project Architecture
 
 ### Terraform Structure
+Each subdirectory is an independent Terraform project with its own state and backend configuration.
+
 - **terraform/cloudflare/**: Manages romira.dev domain DNS records
-- **terraform/oci/**: Oracle Cloud Infrastructure resources
-  - Each subdirectory is an independent Terraform project with its own state
+- **terraform/oci/**: Oracle Cloud Infrastructure (tokyo-always-free, osaka-always-free)
   - Backend: OCI Object Storage (S3-compatible)
-  - Uses tfmigrate for import history management
+- **terraform/aws/**: AWS resources (RaidHawk project - Lambda, DynamoDB, CloudWatch, IAM)
+  - Project-specific README contains KMS encryption commands
+
+All Terraform projects use tfmigrate for import history management (see `tfmigrate/` directories).
 
 ### Ansible Structure
-- **ansible/roles/**: Reusable configuration modules (Docker, MySQL, OpenLiteSpeed, etc.)
+- **ansible/roles/**: Reusable configuration modules (docker, postgresql, brew, MySQL, OpenLiteSpeed, Tailscale, etc.)
 - **ansible/inventories/**: Host-specific configurations
   - Each inventory has `group_vars/all/vars.yml` and `vault.yml`
-  - Vault password file: `.vault-password-file`
-- **Playbooks**:
-  - `site.yml`: Main playbook
-  - `develop_*.yml`: Development environment setup
-  - `homeserver.yml`, `wakaba.yml`, `hinokuni.yml`: Server-specific
+  - Vault password is auto-loaded via ansible.cfg
+- **Playbooks**: `site.yml` (main), `develop_*.yml` (dev environments), server-specific (homeserver.yml, wakaba.yml, hinokuni.yml, oci-tokyo-ampere.yml)
 
 ### Security Considerations
 - Sensitive data must be in `vault.yml` files (already encrypted)
@@ -74,12 +79,6 @@ When modifying Terraform:
 3. Run `terraform plan` to verify changes
 
 When modifying Ansible:
-1. Run `ansible-lint .`
+1. Run `ansible-lint .` from ansible/ directory
 2. Run playbook with `--check --diff` flags
 3. Verify no sensitive data is exposed in plain text
-
-## Repository-Specific Notes
-
-- This manages personal infrastructure across OCI (Oracle Cloud) and Cloudflare
-- Supports Ubuntu, Windows, and macOS configuration management
-- All Ansible commands must include vault password file (configured in ansible.cfg)

--- a/ansible/inventories/oci-tokyo-ampere/group_vars/all/vars.yml
+++ b/ansible/inventories/oci-tokyo-ampere/group_vars/all/vars.yml
@@ -9,3 +9,10 @@ postgresql:
     - name: blog
       password: "{{ vault_postgresql_blog_password }}"
       db: blog_romira_dev
+
+# Docker data-root migration settings
+docker:
+  migrate_data_root: true
+  data_root: "/mnt/d/docker"
+  old_data_root: "/var/lib/docker"
+  remove_old_data: false

--- a/ansible/oci-tokyo-ampere.yml
+++ b/ansible/oci-tokyo-ampere.yml
@@ -3,6 +3,7 @@
   hosts: oci_tokyo_ampere
   roles:
     - apt
+    - docker
     - postgresql
   tags: oci-tokyo-ampere
 

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,2 +1,29 @@
 ---
 # defaults file for docker
+
+# Docker data-root migration settings
+docker:
+  # Enable data-root migration (must be explicitly set to true)
+  migrate_data_root: false
+
+  # New data-root path
+  data_root: "/var/lib/docker"
+
+  # Old data-root path (migration source)
+  old_data_root: "/var/lib/docker"
+
+  # rsync options for data migration
+  rsync_opts: "-aHAXxvP"
+
+  # Remove old data after migration (recommended: false for manual cleanup)
+  remove_old_data: false
+
+# Additional daemon.json configuration (optional)
+# Example:
+#   docker_daemon_config:
+#     storage-driver: "overlay2"
+#     log-driver: "json-file"
+#     log-opts:
+#       max-size: "10m"
+#       max-file: "3"
+docker_daemon_config: {}

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -1,2 +1,16 @@
 ---
 # handlers file for docker
+
+- name: Restart docker
+  ansible.builtin.systemd:
+    name: docker.service
+    state: restarted
+    daemon_reload: true
+  become: true
+
+- name: Reload docker
+  ansible.builtin.systemd:
+    name: docker.service
+    state: reloaded
+    daemon_reload: true
+  become: true

--- a/ansible/roles/docker/tasks/install.yml
+++ b/ansible/roles/docker/tasks/install.yml
@@ -1,0 +1,93 @@
+---
+# tasks file for docker installation
+
+- name: Update apt package index
+  ansible.builtin.apt:
+    update_cache: true
+  become: true
+  tags:
+    - docker
+    - docker-install
+
+- name: Install required system packages
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - rsync
+    state: present
+  become: true
+  tags:
+    - docker
+    - docker-install
+
+- name: Create directory for Docker GPG key
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+  become: true
+  tags:
+    - docker
+    - docker-install
+
+- name: Download Docker's official GPG key
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+  become: true
+  tags:
+    - docker
+    - docker-install
+
+- name: Get OS release codename
+  ansible.builtin.command: lsb_release -cs
+  register: os_codename
+  changed_when: false
+  tags:
+    - docker
+    - docker-install
+
+- name: Get dpkg architecture
+  ansible.builtin.command: dpkg --print-architecture
+  register: dpkg_arch
+  changed_when: false
+  tags:
+    - docker
+    - docker-install
+
+- name: Add Docker repository to APT sources
+  ansible.builtin.apt_repository:
+    repo: "deb [arch={{ dpkg_arch.stdout }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ os_codename.stdout }} stable"
+    filename: docker
+    state: present
+  become: true
+  tags:
+    - docker
+    - docker-install
+
+- name: Install Docker and related packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+  become: true
+  tags:
+    - docker
+    - docker-install
+
+- name: Ensure Docker service is started and enabled
+  ansible.builtin.systemd:
+    name: docker.service
+    state: started
+    enabled: true
+  become: true
+  tags:
+    - docker
+    - docker-install

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,52 +1,32 @@
 ---
 # tasks file for docker
-- name: Update apt package index
-  ansible.builtin.apt:
-    update_cache: yes
-  become: true
 
-- name: Install required system packages
-  ansible.builtin.apt:
-    name: "{{ packages }}"
-  become: true
-  vars:
-    packages:
-      - ca-certificates
-      - curl
+# Docker installation
+- name: Include Docker installation tasks
+  ansible.builtin.include_tasks: install.yml
+  tags:
+    - docker
+    - docker-install
 
-- name: Create directory for Docker GPG key
-  ansible.builtin.file:
-    path: /etc/apt/keyrings
-    state: directory
-    mode: '0755'
+# Docker daemon.json configuration (for data-root and other settings)
+- name: Ensure Docker daemon.json is configured
+  ansible.builtin.template:
+    src: daemon.json.j2
+    dest: /etc/docker/daemon.json
+    owner: root
+    group: root
+    mode: "0644"
   become: true
+  notify: Restart docker
+  when: (docker.data_root | default('/var/lib/docker')) != "/var/lib/docker" or (docker_daemon_config | default({}) | length > 0)
+  tags:
+    - docker
+    - docker-config
 
-- name: Download Docker's official GPG key
-  ansible.builtin.get_url:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    dest: /etc/apt/keyrings/docker.asc
-    mode: '0644'
-  become: true
-
-- name: Add Docker repository to APT sources
-  ansible.builtin.shell: |
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-  become: true
-
-- name: Update apt package index
-  ansible.builtin.apt:
-    update_cache: yes
-  become: true
-
-- name: Install Docker and related packages
-  ansible.builtin.apt:
-    name: "{{ packages }}"
-    state: present
-  become: true
-  vars:
-    packages:
-      - docker-ce
-      - docker-ce-cli
-      - containerd.io
-      - docker-buildx-plugin
-      - docker-compose-plugin
+# Data-root migration process
+- name: Include Docker data-root migration tasks
+  ansible.builtin.include_tasks: migrate_data_root.yml
+  when: docker.migrate_data_root | default(false)
+  tags:
+    - docker
+    - docker-migration

--- a/ansible/roles/docker/tasks/migrate_data_root.yml
+++ b/ansible/roles/docker/tasks/migrate_data_root.yml
@@ -1,0 +1,192 @@
+---
+# tasks file for docker data-root migration
+
+# Check if migration is needed
+- name: Check current Docker data-root
+  ansible.builtin.command: docker info --format '{{ '{{' }}.DockerRootDir{{ '}}' }}'
+  register: current_docker_root
+  changed_when: false
+  failed_when: false
+  become: true
+  tags:
+    - docker
+    - docker-migration
+
+- name: Check if new data-root directory has data
+  ansible.builtin.stat:
+    path: "{{ docker.data_root }}/overlay2"
+  register: new_data_root_stat
+  become: true
+  tags:
+    - docker
+    - docker-migration
+
+- name: Set migration needed fact
+  ansible.builtin.set_fact:
+    docker_migration_needed: >-
+      {{
+        current_docker_root.rc == 0 and
+        current_docker_root.stdout != docker.data_root and
+        not new_data_root_stat.stat.exists
+      }}
+  tags:
+    - docker
+    - docker-migration
+
+# Migration process (conditional)
+- name: Migrate Docker data-root
+  when: docker_migration_needed | default(false)
+  block:
+    - name: Ensure new Docker data directory exists
+      ansible.builtin.file:
+        path: "{{ docker.data_root }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0710"
+      become: true
+
+    - name: Stop Docker socket
+      ansible.builtin.systemd:
+        name: docker.socket
+        state: stopped
+      become: true
+
+    - name: Stop Docker service for migration
+      ansible.builtin.systemd:
+        name: docker.service
+        state: stopped
+      become: true
+
+    - name: Stop containerd service for migration
+      ansible.builtin.systemd:
+        name: containerd.service
+        state: stopped
+      become: true
+
+    - name: Wait for Docker processes to stop
+      ansible.builtin.shell: |
+        while pgrep -x dockerd > /dev/null; do sleep 1; done
+      become: true
+      changed_when: false
+      timeout: 60
+
+    - name: Sync Docker data to new location
+      ansible.builtin.command: >
+        rsync {{ docker.rsync_opts | default('-aHAXxvP') }}
+        {{ docker.old_data_root | default('/var/lib/docker') }}/
+        {{ docker.data_root }}/
+      become: true
+      register: rsync_result
+
+    - name: Display rsync result
+      ansible.builtin.debug:
+        msg: "Rsync completed. Please verify data integrity."
+      when: rsync_result.changed
+
+    - name: Ensure Docker daemon.json is configured with new data-root
+      ansible.builtin.template:
+        src: daemon.json.j2
+        dest: /etc/docker/daemon.json
+        owner: root
+        group: root
+        mode: "0644"
+      become: true
+
+    - name: Start containerd service
+      ansible.builtin.systemd:
+        name: containerd.service
+        state: started
+      become: true
+
+    - name: Start Docker service
+      ansible.builtin.systemd:
+        name: docker.service
+        state: started
+      become: true
+
+    - name: Wait for Docker to be ready
+      ansible.builtin.command: docker info
+      register: docker_info_check
+      until: docker_info_check.rc == 0
+      retries: 10
+      delay: 5
+      changed_when: false
+      become: true
+
+    - name: Verify new data-root is active
+      ansible.builtin.command: docker info --format '{{ '{{' }}.DockerRootDir{{ '}}' }}'
+      register: verify_docker_root
+      changed_when: false
+      failed_when: verify_docker_root.stdout != docker.data_root
+      become: true
+
+    - name: Display migration success message
+      ansible.builtin.debug:
+        msg: |
+          Docker data-root migration completed successfully!
+          Old location: {{ docker.old_data_root | default('/var/lib/docker') }}
+          New location: {{ docker.data_root }}
+
+          IMPORTANT: After verifying everything works correctly,
+          you can manually remove the old data:
+            sudo rm -rf {{ docker.old_data_root | default('/var/lib/docker') }}
+
+  rescue:
+    - name: Migration failed - attempting rollback
+      ansible.builtin.debug:
+        msg: "Migration failed. Attempting to restore Docker service..."
+
+    - name: Remove daemon.json if migration failed before rsync
+      ansible.builtin.file:
+        path: /etc/docker/daemon.json
+        state: absent
+      become: true
+      when: rsync_result is not defined or rsync_result.failed | default(false)
+
+    - name: Start containerd service after failed migration
+      ansible.builtin.systemd:
+        name: containerd.service
+        state: started
+      become: true
+      ignore_errors: true
+
+    - name: Start Docker service after failed migration
+      ansible.builtin.systemd:
+        name: docker.service
+        state: started
+      become: true
+      ignore_errors: true
+
+    - name: Fail with migration error
+      ansible.builtin.fail:
+        msg: "Docker data-root migration failed. Docker service has been restored to original state."
+
+  tags:
+    - docker
+    - docker-migration
+
+# Already migrated message
+- name: Already migrated message
+  ansible.builtin.debug:
+    msg: "Docker data-root is already at {{ docker.data_root }}. No migration needed."
+  when: not (docker_migration_needed | default(false))
+  tags:
+    - docker
+    - docker-migration
+
+# Optional: Remove old Docker data (recommended: manual cleanup)
+- name: Remove old Docker data (if configured)
+  ansible.builtin.file:
+    path: "{{ docker.old_data_root | default('/var/lib/docker') }}"
+    state: absent
+  become: true
+  when:
+    - docker.remove_old_data | default(false)
+    - docker_migration_needed | default(false)
+    - verify_docker_root is defined
+    - verify_docker_root.stdout == docker.data_root
+  tags:
+    - docker
+    - docker-migration
+    - cleanup

--- a/ansible/roles/docker/templates/daemon.json.j2
+++ b/ansible/roles/docker/templates/daemon.json.j2
@@ -1,0 +1,10 @@
+{
+{% if docker.data_root is defined and docker.data_root != "/var/lib/docker" %}
+  "data-root": "{{ docker.data_root }}"{% if (docker_daemon_config | default({})) | length > 0 %},{% endif %}
+
+{% endif %}
+{% for key, value in (docker_daemon_config | default({})).items() %}
+  "{{ key }}": {{ value | to_json }}{% if not loop.last %},{% endif %}
+
+{% endfor %}
+}


### PR DESCRIPTION
## Summary

- Docker ロールに data-root 移行機能を追加
- oci-tokyo-ampere で `/var/lib/docker` → `/mnt/d/docker` への移行を設定
- CLAUDE.md を最新のプロジェクト構造に更新

## 変更内容

### Docker ロール拡張
- `tasks/main.yml` をリファクタリングし、install.yml と migrate_data_root.yml に分離
- `defaults/main.yml` に移行用変数を追加
- `handlers/main.yml` に restart/reload ハンドラーを追加
- `templates/daemon.json.j2` を新規作成

### 移行機能の特徴
- 冪等性: 移行済みの場合は自動でスキップ
- 安全なサービス停止順序: docker.socket → docker → containerd
- rsync でハードリンクを保持してデータコピー
- 失敗時の自動ロールバック
- 移行成功の検証

### oci-tokyo-ampere 設定
- docker ロールを playbook に追加
- vars.yml に移行設定を追加

## Test plan

- [x] ansible-lint 通過
- [x] oci-tokyo-ampere で実際に移行を実行し成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)