### PR TITLE
feat: macOS full setup with AI tools and defaults management

### DIFF
--- a/ansible/develop_macOS.yml
+++ b/ansible/develop_macOS.yml
@@ -15,25 +15,39 @@
 - name: User environment setup
   hosts: develop_macOS
   tasks:
-    - import_tasks: tasks/develop_ubuntu/symlink.yml
+    - name: Import symlink tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/symlink.yml
       tags: [develop_configuration, symlink]
 
-    - import_tasks: tasks/develop_ubuntu/ssh.yml
+    - name: Import ssh tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/ssh.yml
       tags: [develop_configuration, ssh]
 
-    - import_tasks: tasks/develop_ubuntu/zprezto.yml
+    - name: Import zprezto tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/zprezto.yml
       tags: [develop_configuration, zprezto]
 
-    - import_tasks: tasks/develop_macOS/fish.yml
+    - name: Import fish tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_macOS/fish.yml
       tags: [develop_configuration, fish]
 
-    - import_tasks: tasks/develop_ubuntu/rustup.yml
+    - name: Import rustup tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/rustup.yml
       tags: [develop_configuration, rustup]
 
-    - import_tasks: tasks/develop_ubuntu/tmux.yml
+    - name: Import tmux tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/tmux.yml
       tags: [develop_configuration, tmux]
 
-    - import_tasks: tasks/develop_macOS/macos_defaults.yml
+    - name: Import macos_defaults tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_macOS/macos_defaults.yml
       tags: [develop_configuration, macos_defaults]
   tags:
     - develop_configuration

--- a/ansible/develop_ubuntu.yml
+++ b/ansible/develop_ubuntu.yml
@@ -39,32 +39,44 @@
   become: true
   become_user: "{{ setup_user }}"
   tasks:
-    - import_tasks: tasks/develop_ubuntu/symlink.yml
+    - name: Import symlink tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/symlink.yml
       tags:
         - develop_configuration
         - symlink
 
-    - import_tasks: tasks/develop_ubuntu/ssh.yml
+    - name: Import ssh tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/ssh.yml
       tags:
         - develop_configuration
         - ssh
 
-    - import_tasks: tasks/develop_ubuntu/zprezto.yml
+    - name: Import zprezto tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/zprezto.yml
       tags:
         - develop_configuration
         - zprezto
 
-    - import_tasks: tasks/develop_ubuntu/fish.yml
+    - name: Import fish tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/fish.yml
       tags:
         - develop_configuration
         - fish
 
-    - import_tasks: tasks/develop_ubuntu/rustup.yml
+    - name: Import rustup tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/rustup.yml
       tags:
         - develop_configuration
         - rustup
 
-    - import_tasks: tasks/develop_ubuntu/tmux.yml
+    - name: Import tmux tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/tmux.yml
       tags:
         - develop_configuration
         - tmux
@@ -77,7 +89,9 @@
   become: true
   become_user: "{{ setup_user }}"
   tasks:
-    - import_tasks: tasks/develop_ubuntu/wsl.yml
+    - name: Import wsl tasks
+      ansible.builtin.import_tasks:
+        file: tasks/develop_ubuntu/wsl.yml
       tags:
         - develop_configuration
         - wsl

--- a/ansible/inventories/develop_macOS/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_macOS/group_vars/all/vars.yml
@@ -61,5 +61,3 @@ develop_configuration:
       dest: ~/.claude/CLAUDE.md
     - src: ~/.config/romira-s-config/claude-code/settings.json
       dest: ~/.claude/settings.json
-    - src: ~/.config/romira-s-config/claude-code/skills
-      dest: ~/.claude/skills

--- a/ansible/inventories/develop_macOS/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_macOS/group_vars/all/vars.yml
@@ -2,7 +2,35 @@ additional_path: /opt/homebrew/bin:/opt/homebrew/sbin:~/.cargo/bin
 
 macos_defaults:
   dock_tilesize: 48
+  dock_magnification: true
   dock_largesize: 128
+  dock_show_recents: false
+  dock_autohide: false
+  dock_autohide_delay: 0.5
+  dock_orientation: bottom
+  dock_mineffect: genie
+  dock_static_only: false
+  dock_mru_spaces: true
+  dock_expose_group_apps: false
+  finder_show_all_files: "YES"
+  finder_show_pathbar: true
+  finder_show_status_bar: false
+  finder_default_search_scope: SCcf
+  finder_preferred_view_style: icnv
+  finder_sort_folders_first: false
+  finder_extension_change_warning: true
+  finder_save_to_cloud: true
+  global_show_all_extensions: true
+  global_press_and_hold_enabled: false
+  global_close_always_confirms_changes: false
+  keyboard_ui_mode: 0
+  trackpad_tap_to_click: true
+  screenshot_location: ~/Pictures/Screenshots
+  screenshot_type: png
+  screenshot_disable_shadow: false
+  screenshot_show_thumbnail: false
+  launch_services_quarantine: true
+  timemachine_do_not_offer_new_disks: false
 
 brew_extra_packages:
   - curl

--- a/ansible/inventories/develop_macOS/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_macOS/group_vars/all/vars.yml
@@ -36,6 +36,9 @@ develop_configuration:
     - ~/.local/bin/
     - ~/workspace/repositories
     - ~/.claude/
+    - ~/.codex/
+    - ~/.gemini/
+    - ~/.config/opencode/
   symbolic_links:
     - src: ~/.config/romira-s-config/git/.gitconfig
       dest: ~/.gitconfig
@@ -59,5 +62,19 @@ develop_configuration:
       dest: ~/.config/mcfly/mcfly.fish
     - src: ~/.config/romira-s-config/claude-code/CLAUDE.md
       dest: ~/.claude/CLAUDE.md
+    - src: ~/.config/romira-s-config/claude-code/CLAUDE.md
+      dest: ~/.codex/AGENTS.md
+    - src: ~/.config/romira-s-config/claude-code/CLAUDE.md
+      dest: ~/.gemini/GEMINI.md
+    - src: ~/.config/romira-s-config/claude-code/CLAUDE.md
+      dest: ~/.config/opencode/AGENTS.md
     - src: ~/.config/romira-s-config/claude-code/settings.json
       dest: ~/.claude/settings.json
+
+ai_skills:
+  src: ~/.config/romira-s-config/ai-skills
+  destinations:
+    - ~/.claude/skills
+    - ~/.codex/skills
+    - ~/.gemini/skills
+    - ~/.config/opencode/skills

--- a/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
@@ -50,6 +50,9 @@ develop_configuration:
     - ~/.local/bin/
     - ~/workspace/repositories
     - ~/.claude/
+    - ~/.codex/
+    - ~/.gemini/
+    - ~/.config/opencode/
   symbolic_links:
     - src: ~/.config/romira-s-config/git/.gitconfig
       dest: ~/.gitconfig
@@ -79,6 +82,12 @@ develop_configuration:
       dest: ~/.config/mcfly/mcfly.fish
     - src: ~/.config/romira-s-config/claude-code/CLAUDE.md
       dest: ~/.claude/CLAUDE.md
+    - src: ~/.config/romira-s-config/claude-code/CLAUDE.md
+      dest: ~/.codex/AGENTS.md
+    - src: ~/.config/romira-s-config/claude-code/CLAUDE.md
+      dest: ~/.gemini/GEMINI.md
+    - src: ~/.config/romira-s-config/claude-code/CLAUDE.md
+      dest: ~/.config/opencode/AGENTS.md
     - src: ~/.config/romira-s-config/claude-code/settings.json
       dest: ~/.claude/settings.json
   wsl_symbolic_links:
@@ -111,5 +120,12 @@ user:
       authorized_keys: https://github.com/Romira915.keys
   absent_users: []
 additional_path: /home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/romira/.cargo/bin
+ai_skills:
+  src: ~/.config/romira-s-config/ai-skills
+  destinations:
+    - ~/.claude/skills
+    - ~/.codex/skills
+    - ~/.gemini/skills
+    - ~/.config/opencode/skills
 brew_extra_packages:
   - xsel

--- a/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
@@ -81,8 +81,6 @@ develop_configuration:
       dest: ~/.claude/CLAUDE.md
     - src: ~/.config/romira-s-config/claude-code/settings.json
       dest: ~/.claude/settings.json
-    - src: ~/.config/romira-s-config/claude-code/skills
-      dest: ~/.claude/skills
   wsl_symbolic_links:
     - src: /mnt/c/Windows/System32/clip.exe
       dest: ~/.local/bin/clip

--- a/ansible/roles/bitwarden/tasks/main.yml
+++ b/ansible/roles/bitwarden/tasks/main.yml
@@ -6,8 +6,12 @@
   tags:
     - bitwarden
 
-- import_tasks: unix_bitwarden.yml
+- name: Import unix bitwarden tasks
+  ansible.builtin.import_tasks:
+    file: unix_bitwarden.yml
   when: ansible_facts.system in ['Linux', 'Darwin']
 
-- import_tasks: win_bitwarden.yml
+- name: Import windows bitwarden tasks
+  ansible.builtin.import_tasks:
+    file: win_bitwarden.yml
   when: ansible_facts.system in ['Win32NT']

--- a/ansible/roles/bitwarden/tasks/unix_bitwarden.yml
+++ b/ansible/roles/bitwarden/tasks/unix_bitwarden.yml
@@ -9,7 +9,8 @@
   tags:
     - bitwarden
 
-- block:
+- name: Configure bitwarden server
+  block:
     - name: Check bw config server value
       ansible.builtin.command: "bw config server"
       environment:

--- a/ansible/roles/bitwarden/tasks/win_bitwarden.yml
+++ b/ansible/roles/bitwarden/tasks/win_bitwarden.yml
@@ -7,7 +7,8 @@
     - bitwarden
     - scoop
 
-- block:
+- name: Configure bitwarden server
+  block:
     - name: Check bw config server value
       ansible.windows.win_command: bw config server
       changed_when: false
@@ -21,7 +22,8 @@
       tags:
         - bitwarden
 
-- block:
+- name: Login to bitwarden
+  block:
     - name: Check bw login status
       ansible.windows.win_command: bw login --check
       failed_when: false

--- a/ansible/tasks/develop_macOS/macos_defaults.yml
+++ b/ansible/tasks/develop_macOS/macos_defaults.yml
@@ -1,91 +1,256 @@
 ---
 # Dock
+# 通常時のアイコンサイズ (px)
 - name: "Dock: Set icon size to {{ macos_defaults.dock_tilesize }}"
   community.general.osx_defaults:
     domain: com.apple.dock
     key: tilesize
-    type: int
+    type: float
     value: "{{ macos_defaults.dock_tilesize }}"
 
-- name: "Dock: Enable magnification"
+# マウスオーバー時のアイコン拡大を有効にする
+- name: "Dock: Set magnification to {{ macos_defaults.dock_magnification }}"
   community.general.osx_defaults:
     domain: com.apple.dock
     key: magnification
     type: bool
-    value: true
+    value: "{{ macos_defaults.dock_magnification }}"
 
+# 拡大時のアイコンサイズ (px)
 - name: "Dock: Set magnified icon size to {{ macos_defaults.dock_largesize }}"
   community.general.osx_defaults:
     domain: com.apple.dock
     key: largesize
-    type: int
+    type: float
     value: "{{ macos_defaults.dock_largesize }}"
 
-- name: "Dock: Hide recent applications"
+# 最近使ったアプリのセクションを表示する
+- name: "Dock: Set show-recents to {{ macos_defaults.dock_show_recents }}"
   community.general.osx_defaults:
     domain: com.apple.dock
     key: show-recents
     type: bool
-    value: false
+    value: "{{ macos_defaults.dock_show_recents }}"
+
+# Dockを自動的に隠す
+- name: "Dock: Set autohide to {{ macos_defaults.dock_autohide }}"
+  community.general.osx_defaults:
+    domain: com.apple.dock
+    key: autohide
+    type: bool
+    value: "{{ macos_defaults.dock_autohide }}"
+
+# 自動非表示の遅延時間 (秒)
+- name: "Dock: Set autohide delay to {{ macos_defaults.dock_autohide_delay }}"
+  community.general.osx_defaults:
+    domain: com.apple.dock
+    key: autohide-delay
+    type: float
+    value: "{{ macos_defaults.dock_autohide_delay }}"
+
+# Dockの位置 (bottom/left/right)
+- name: "Dock: Set orientation to {{ macos_defaults.dock_orientation }}"
+  community.general.osx_defaults:
+    domain: com.apple.dock
+    key: orientation
+    type: string
+    value: "{{ macos_defaults.dock_orientation }}"
+
+# 最小化アニメーション (genie/scale)
+- name: "Dock: Set minimize effect to {{ macos_defaults.dock_mineffect }}"
+  community.general.osx_defaults:
+    domain: com.apple.dock
+    key: mineffect
+    type: string
+    value: "{{ macos_defaults.dock_mineffect }}"
+
+# アクティブなアプリのみDockに表示する
+- name: "Dock: Set static-only to {{ macos_defaults.dock_static_only }}"
+  community.general.osx_defaults:
+    domain: com.apple.dock
+    key: static-only
+    type: bool
+    value: "{{ macos_defaults.dock_static_only }}"
+
+# Mission Control: 使用状況に基づいてSpacesを自動並べ替え
+- name: "Dock: Set mru-spaces to {{ macos_defaults.dock_mru_spaces }}"
+  community.general.osx_defaults:
+    domain: com.apple.dock
+    key: mru-spaces
+    type: bool
+    value: "{{ macos_defaults.dock_mru_spaces }}"
+
+# Mission Control: アプリケーション別にウィンドウをグループ化
+- name: "Dock: Set expose-group-apps to {{ macos_defaults.dock_expose_group_apps }}"
+  community.general.osx_defaults:
+    domain: com.apple.dock
+    key: expose-group-apps
+    type: bool
+    value: "{{ macos_defaults.dock_expose_group_apps }}"
 
 # Finder
-- name: "Finder: Show hidden files"
+# 隠しファイル(ドットファイル)を表示する
+- name: "Finder: Set AppleShowAllFiles to {{ macos_defaults.finder_show_all_files }}"
   community.general.osx_defaults:
     domain: com.apple.finder
     key: AppleShowAllFiles
-    type: bool
-    value: true
+    type: string
+    value: "{{ macos_defaults.finder_show_all_files }}"
 
-- name: "Finder: Show path bar"
+# ウィンドウ下部にパスバーを表示する
+- name: "Finder: Set ShowPathbar to {{ macos_defaults.finder_show_pathbar }}"
   community.general.osx_defaults:
     domain: com.apple.finder
     key: ShowPathbar
     type: bool
-    value: true
+    value: "{{ macos_defaults.finder_show_pathbar }}"
 
-- name: "Finder: Search current folder by default"
+# ウィンドウ下部にステータスバーを表示する
+- name: "Finder: Set ShowStatusBar to {{ macos_defaults.finder_show_status_bar }}"
+  community.general.osx_defaults:
+    domain: com.apple.finder
+    key: ShowStatusBar
+    type: bool
+    value: "{{ macos_defaults.finder_show_status_bar }}"
+
+# 検索時のデフォルトスコープ (SCcf=現在のフォルダ, SCsp=前回のスコープ, SCev=Mac全体)
+- name: "Finder: Set FXDefaultSearchScope to {{ macos_defaults.finder_default_search_scope }}"
   community.general.osx_defaults:
     domain: com.apple.finder
     key: FXDefaultSearchScope
     type: string
-    value: SCcf
+    value: "{{ macos_defaults.finder_default_search_scope }}"
+
+# デフォルト表示スタイル (icnv=アイコン, Nlsv=リスト, clmv=カラム, Flwv=ギャラリー)
+- name: "Finder: Set FXPreferredViewStyle to {{ macos_defaults.finder_preferred_view_style }}"
+  community.general.osx_defaults:
+    domain: com.apple.finder
+    key: FXPreferredViewStyle
+    type: string
+    value: "{{ macos_defaults.finder_preferred_view_style }}"
+
+# フォルダを常にリストの先頭に表示する
+- name: "Finder: Set _FXSortFoldersFIrst to {{ macos_defaults.finder_sort_folders_first }}"
+  community.general.osx_defaults:
+    domain: com.apple.finder
+    key: _FXSortFoldersFIrst
+    type: bool
+    value: "{{ macos_defaults.finder_sort_folders_first }}"
+
+# 拡張子変更時に警告を表示する
+- name: "Finder: Set FXEnableExtensionChangeWarning to {{ macos_defaults.finder_extension_change_warning }}"
+  community.general.osx_defaults:
+    domain: com.apple.finder
+    key: FXEnableExtensionChangeWarning
+    type: bool
+    value: "{{ macos_defaults.finder_extension_change_warning }}"
+
+# 新規ファイルの保存先をiCloudにする (falseでローカル優先)
+- name: "Finder: Set NSDocumentSaveNewDocumentsToCloud to {{ macos_defaults.finder_save_to_cloud }}"
+  community.general.osx_defaults:
+    domain: NSGlobalDomain
+    key: NSDocumentSaveNewDocumentsToCloud
+    type: bool
+    value: "{{ macos_defaults.finder_save_to_cloud }}"
 
 # Global
-- name: "Global: Show all file extensions"
+# 拡張子を常に表示する
+- name: "Global: Set AppleShowAllExtensions to {{ macos_defaults.global_show_all_extensions }}"
   community.general.osx_defaults:
     domain: NSGlobalDomain
     key: AppleShowAllExtensions
     type: bool
-    value: true
+    value: "{{ macos_defaults.global_show_all_extensions }}"
 
-- name: "Global: Enable key repeat (disable press-and-hold)"
+# キーの長押しで特殊文字入力ではなくキーリピートを有効にする
+- name: "Global: Set ApplePressAndHoldEnabled to {{ macos_defaults.global_press_and_hold_enabled }}"
   community.general.osx_defaults:
     domain: NSGlobalDomain
     key: ApplePressAndHoldEnabled
     type: bool
-    value: false
+    value: "{{ macos_defaults.global_press_and_hold_enabled }}"
+
+# 閉じる時に常に保存確認ダイアログを表示する
+- name: "Global: Set NSCloseAlwaysConfirmsChanges to {{ macos_defaults.global_close_always_confirms_changes }}"
+  community.general.osx_defaults:
+    domain: NSGlobalDomain
+    key: NSCloseAlwaysConfirmsChanges
+    type: bool
+    value: "{{ macos_defaults.global_close_always_confirms_changes }}"
+
+# Keyboard
+# Tabキーによるフォーカス移動 (0=テキストフィールドのみ, 2=すべてのコントロール)
+- name: "Keyboard: Set AppleKeyboardUIMode to {{ macos_defaults.keyboard_ui_mode }}"
+  community.general.osx_defaults:
+    domain: NSGlobalDomain
+    key: AppleKeyboardUIMode
+    type: int
+    value: "{{ macos_defaults.keyboard_ui_mode }}"
 
 # Trackpad
-- name: "Trackpad: Enable tap to click"
+# タップでクリックを有効にする
+- name: "Trackpad: Set tap to click to {{ macos_defaults.trackpad_tap_to_click }}"
   community.general.osx_defaults:
     domain: com.apple.AppleMultitouchTrackpad
     key: Clicking
     type: bool
-    value: true
+    value: "{{ macos_defaults.trackpad_tap_to_click }}"
 
 # Screenshot
+# スクリーンショットの保存先ディレクトリ
 - name: "Screenshot: Ensure save directory exists"
   ansible.builtin.file:
-    path: ~/Pictures/Screenshots
+    path: "{{ macos_defaults.screenshot_location }}"
     state: directory
     mode: "0755"
 
-- name: "Screenshot: Set save location"
+- name: "Screenshot: Set save location to {{ macos_defaults.screenshot_location }}"
   community.general.osx_defaults:
     domain: com.apple.screencapture
     key: location
     type: string
-    value: ~/Pictures/Screenshots
+    value: "{{ macos_defaults.screenshot_location }}"
+
+# 保存形式 (png/jpg/pdf/tiff/gif/bmp)
+- name: "Screenshot: Set format to {{ macos_defaults.screenshot_type }}"
+  community.general.osx_defaults:
+    domain: com.apple.screencapture
+    key: type
+    type: string
+    value: "{{ macos_defaults.screenshot_type }}"
+
+# ウィンドウ撮影時の影を無効化する
+- name: "Screenshot: Set disable-shadow to {{ macos_defaults.screenshot_disable_shadow }}"
+  community.general.osx_defaults:
+    domain: com.apple.screencapture
+    key: disable-shadow
+    type: bool
+    value: "{{ macos_defaults.screenshot_disable_shadow }}"
+
+# 撮影後のサムネイルプレビューを表示する
+- name: "Screenshot: Set show-thumbnail to {{ macos_defaults.screenshot_show_thumbnail }}"
+  community.general.osx_defaults:
+    domain: com.apple.screencapture
+    key: show-thumbnail
+    type: bool
+    value: "{{ macos_defaults.screenshot_show_thumbnail }}"
+
+# Misc
+# ダウンロードしたファイルの検疫警告(「開いてもよろしいですか？」)を表示する
+- name: "LaunchServices: Set LSQuarantine to {{ macos_defaults.launch_services_quarantine }}"
+  community.general.osx_defaults:
+    domain: com.apple.LaunchServices
+    key: LSQuarantine
+    type: bool
+    value: "{{ macos_defaults.launch_services_quarantine }}"
+
+# 新しいディスク接続時にTime Machineバックアップ先として提案しない
+- name: "TimeMachine: Set DoNotOfferNewDisksForBackup to {{ macos_defaults.timemachine_do_not_offer_new_disks }}"
+  community.general.osx_defaults:
+    domain: com.apple.TimeMachine
+    key: DoNotOfferNewDisksForBackup
+    type: bool
+    value: "{{ macos_defaults.timemachine_do_not_offer_new_disks }}"
 
 # Restart affected apps
 - name: Restart Dock to apply settings

--- a/ansible/tasks/develop_ubuntu/symlink.yml
+++ b/ansible/tasks/develop_ubuntu/symlink.yml
@@ -31,25 +31,33 @@
     force: true
   loop: "{{ develop_configuration.symbolic_links }}"
 
-- name: Ensure ~/.claude/skills directory exists
+- name: Ensure AI tool skills directories exist
   ansible.builtin.file:
-    path: ~/.claude/skills
+    path: "{{ item }}"
     state: directory
     mode: "0755"
+  loop: "{{ ai_skills.destinations }}"
 
-- name: Find claude skill files
+- name: Check if AI skills source directory exists
+  ansible.builtin.stat:
+    path: "{{ ai_skills.src }}"
+  register: ai_skills_src_stat
+
+- name: Find AI skill entries
   ansible.builtin.find:
-    paths: ~/.config/romira-s-config/claude-code/skills
+    paths: "{{ ai_skills.src }}"
     patterns: "*"
     file_type: any
-  register: claude_skill_files
+  register: ai_skill_entries
+  when: ai_skills_src_stat.stat.exists
 
-- name: Create symbolic links for claude skills
+- name: Create symbolic links for AI skills
   ansible.builtin.file:
-    src: "{{ item.path }}"
-    dest: "~/.claude/skills/{{ item.path | basename }}"
+    src: "{{ item.0.path }}"
+    dest: "{{ item.1 }}/{{ item.0.path | basename }}"
     state: link
     force: true
-  loop: "{{ claude_skill_files.files }}"
+  loop: "{{ ai_skill_entries.files | product(ai_skills.destinations) | list }}"
   loop_control:
-    label: "{{ item.path | basename }}"
+    label: "{{ item.1 }}/{{ item.0.path | basename }}"
+  when: ai_skill_entries.files is defined

--- a/ansible/tasks/develop_ubuntu/symlink.yml
+++ b/ansible/tasks/develop_ubuntu/symlink.yml
@@ -30,3 +30,26 @@
     state: link
     force: true
   loop: "{{ develop_configuration.symbolic_links }}"
+
+- name: Ensure ~/.claude/skills directory exists
+  ansible.builtin.file:
+    path: ~/.claude/skills
+    state: directory
+    mode: "0755"
+
+- name: Find claude skill files
+  ansible.builtin.find:
+    paths: ~/.config/romira-s-config/claude-code/skills
+    patterns: "*"
+    file_type: any
+  register: claude_skill_files
+
+- name: Create symbolic links for claude skills
+  ansible.builtin.file:
+    src: "{{ item.path }}"
+    dest: "~/.claude/skills/{{ item.path | basename }}"
+    state: link
+    force: true
+  loop: "{{ claude_skill_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"


### PR DESCRIPTION
## Summary
- Brew cask対応とパッケージ同期機能を追加
- macOS defaults管理をosx_defaultsモジュールで包括的に実装（Dock, Finder, Keyboard, Screenshot, Trackpad, Mission Control等）
- AI toolsのスキル・指示ファイルをファイル単位シンボリックリンクで管理（Claude Code, Codex CLI, Gemini CLI, OpenCode対応）
- ansible-lint違反を修正（fqcn[action-core], name[missing]）

## Test plan
- [x] `ansible-lint` passed
- [x] `ansible-playbook --check --diff --tags macos_defaults` で全タスクok確認
- [ ] 実機でplaybook全体を実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)