### PR TITLE
feat: add AI rules dynamic symlink and deskflow package

### DIFF
--- a/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
@@ -127,5 +127,9 @@ ai_skills:
     - ~/.codex/skills
     - ~/.gemini/skills
     - ~/.config/opencode/skills
+ai_rules:
+  src: ~/.config/romira-s-config/ai-config/rules
+  destinations:
+    - ~/.claude/rules
 brew_extra_packages:
   - xsel

--- a/ansible/inventories/develop_windows/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_windows/group_vars/all/vars.yml
@@ -62,6 +62,7 @@ chocolatey:
     - valorant
     - ea-app
     - tailscale
+    - deskflow
     - "{{ vault_chocolatey.vault_package }}"
 scoop:
   bucket:

--- a/ansible/tasks/common/symlink.yml
+++ b/ansible/tasks/common/symlink.yml
@@ -61,3 +61,34 @@
   loop_control:
     label: "{{ item.1 }}/{{ item.0.path | basename }}"
   when: ai_skill_entries.files is defined
+
+- name: Ensure AI tool rules directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop: "{{ ai_rules.destinations }}"
+
+- name: Check if AI rules source directory exists
+  ansible.builtin.stat:
+    path: "{{ ai_rules.src }}"
+  register: ai_rules_src_stat
+
+- name: Find AI rule entries
+  ansible.builtin.find:
+    paths: "{{ ai_rules.src }}"
+    patterns: "*"
+    file_type: any
+  register: ai_rule_entries
+  when: ai_rules_src_stat.stat.exists
+
+- name: Create symbolic links for AI rules
+  ansible.builtin.file:
+    src: "{{ item.0.path }}"
+    dest: "{{ item.1 }}/{{ item.0.path | basename }}"
+    state: link
+    force: true
+  loop: "{{ ai_rule_entries.files | product(ai_rules.destinations) | list }}"
+  loop_control:
+    label: "{{ item.1 }}/{{ item.0.path | basename }}"
+  when: ai_rule_entries.files is defined


### PR DESCRIPTION
## Summary
- AI rules を skills と同じ動的発見パターンで `~/.claude/rules/` に symlink する仕組みを追加
- `rules/` 配下にファイルを追加するだけで自動的に展開される
- develop_windows に deskflow パッケージを追加

## Test plan
- [ ] `ansible-lint .` がパスすること
- [ ] converge 実行後、`~/.claude/rules/` 配下に rules ファイルが symlink されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)