### PR TITLE
feat: add MSYS2 fish shell setup and cargo package management

### DIFF
--- a/ansible/develop_windows.yml
+++ b/ansible/develop_windows.yml
@@ -25,10 +25,20 @@
         - develop_configuration
         - ssh
 
+    - import_tasks: tasks/develop_windows/cargo.yml
+      tags:
+        - develop_configuration
+        - cargo
+
     - import_tasks: tasks/develop_windows/msys2.yml
       tags:
         - develop_configuration
         - msys2
+
+    - import_tasks: tasks/develop_windows/fish.yml
+      tags:
+        - develop_configuration
+        - fish
   tags:
     - develop_configuration
 

--- a/ansible/inventories/develop_windows/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_windows/group_vars/all/vars.yml
@@ -86,6 +86,7 @@ scoop:
     - rambox
     - nu
     - starship
+    - zoxide
     - gcc
     - mathpix
     - bitwarden-cli
@@ -118,6 +119,8 @@ develop_configuration:
       dest: C:\Users\{{ ansible_user }}\.bash_profile
     - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\wsl2\.wslconfig
       dest: C:\Users\{{ ansible_user }}\.wslconfig
+    - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\shell\.profile
+      dest: C:\Users\{{ ansible_user }}\.profile
   hard_links:
     - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\WindowsTerminal\settings.json
       dest: C:\Users\{{ ansible_user }}\AppData\Local\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json
@@ -147,10 +150,14 @@ fonts:
       dest: C:\Users\{{ ansible_user }}\.tmp\fonts\Myrica.zip
     - url: https://github.com/tomokuni/Myrica/raw/master/product/MyricaM.zip
       dest: C:\Users\{{ ansible_user }}\.tmp\fonts\MyricaM.zip
+cargo:
+  packages:
+    - mcfly
 msys2:
   packages:
     - zsh
     - fish
+    - python
   login_shell: fish
 optional_feature:
   features:

--- a/ansible/inventories/develop_windows/hosts
+++ b/ansible/inventories/develop_windows/hosts
@@ -6,6 +6,7 @@
 172.28.32.1
 172.23.64.1
 169.254.240.137
+172.21.160.1
 
 [develop_windows:vars]
 ansible_user=romira

--- a/ansible/tasks/develop_windows/cargo.yml
+++ b/ansible/tasks/develop_windows/cargo.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure GNU toolchain is installed
+  ansible.windows.win_shell: rustup toolchain install stable-x86_64-pc-windows-gnu
+  changed_when: "'installing' in cargo_gnu_toolchain.stdout"
+  register: cargo_gnu_toolchain
+
+- name: Install cargo packages
+  ansible.windows.win_shell: rustup run stable-x86_64-pc-windows-gnu cargo install {{ item }}
+  loop: "{{ cargo.packages }}"
+  register: cargo_install
+  changed_when: "'Installed package' in cargo_install.stderr"

--- a/ansible/tasks/develop_windows/fish.yml
+++ b/ansible/tasks/develop_windows/fish.yml
@@ -1,0 +1,47 @@
+---
+- name: Ensure fisher is installed
+  ansible.windows.win_shell: >
+    C:\Users\{{ ansible_user }}\scoop\apps\msys2\current\usr\bin\bash.exe -lc
+    "fish -c 'curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source &&
+    fisher install jorgebucaran/fisher'"
+  changed_when: false
+
+- name: Ensure fisher plugin is installed
+  ansible.windows.win_shell: >
+    C:\Users\{{ ansible_user }}\scoop\apps\msys2\current\usr\bin\bash.exe -lc
+    "fish -c 'fisher install
+    0rax/fish-bd
+    edc/bass'"
+  changed_when: false
+
+- name: Find fish custom function files
+  ansible.windows.win_find:
+    paths: C:\Users\{{ ansible_user }}\.config\romira-s-config\fish\functions
+    patterns: "*.fish"
+  register: fish_custom_functions
+
+- name: Ensure fish functions directory exists
+  ansible.windows.win_file:
+    path: C:\Users\{{ ansible_user }}\.config\fish\functions
+    state: directory
+
+- name: Create symbolic link for fish config
+  ansible.windows.win_shell: >
+    cmd /c mklink
+    "C:\Users\{{ ansible_user }}\.config\fish\config.fish"
+    "C:\Users\{{ ansible_user }}\.config\romira-s-config\fish\config.fish"
+  failed_when: "'already exists' not in create_fish_config_link.stderr and create_fish_config_link.rc != 0"
+  changed_when: create_fish_config_link.rc == 0
+  register: create_fish_config_link
+
+- name: Create symbolic links for fish custom functions
+  ansible.windows.win_shell: >
+    cmd /c mklink
+    "C:\Users\{{ ansible_user }}\.config\fish\functions\{{ item.filename }}"
+    "{{ item.path }}"
+  failed_when: "'already exists' not in create_fish_function_link.stderr and create_fish_function_link.rc != 0"
+  changed_when: create_fish_function_link.rc == 0
+  register: create_fish_function_link
+  loop: "{{ fish_custom_functions.files }}"
+  loop_control:
+    label: "{{ item.filename }}"

--- a/ansible/tasks/develop_windows/msys2.yml
+++ b/ansible/tasks/develop_windows/msys2.yml
@@ -14,7 +14,12 @@
     C:\Users\{{ ansible_user }}\scoop\apps\msys2\current\usr\bin\bash.exe -lc
     "sed -i -e 's/LOGINSHELL=[ba]*[z]*sh/LOGINSHELL={{ msys2.login_shell }}/' /msys2_shell.cmd"
 
-- name: Add Windows PATH to msys2
+- name: Set MSYS2 home directory to Windows home
   ansible.windows.win_shell: >
     C:\Users\{{ ansible_user }}\scoop\apps\msys2\current\usr\bin\bash.exe -lc
-    "grep -q ORIGINAL_PATH /etc/profile || echo 'export PATH=$(cygpath -p -u $ORIGINAL_PATH):$PATH' >> /etc/profile"
+    "sed -i -e 's/^db_home:.*/db_home: windows/' /etc/nsswitch.conf"
+
+- name: Enable MSYS2_PATH_TYPE=inherit
+  ansible.windows.win_shell: >
+    C:\Users\{{ ansible_user }}\scoop\apps\msys2\current\usr\bin\bash.exe -lc
+    "sed -i -e 's/^rem set MSYS2_PATH_TYPE=inherit/set MSYS2_PATH_TYPE=inherit/' /msys2_shell.cmd"


### PR DESCRIPTION
## Summary
- MSYS2のfishシェル環境をUbuntu/macOSと同じパターンで構築
- `db_home: windows`でMSYS2のホームをWindowsホームに統一
- `MSYS2_PATH_TYPE=inherit`でWindows PATHを継承（scoop shims等が使える）
- fisher + bass プラグインインストール、config.fish/custom functions symlink
- cargo packages（mcfly）をGNU toolchainでビルド・管理
- scoop packagesにzoxide追加、msys2 packagesにpython追加

## Changes
| ファイル | 変更 |
|---|---|
| `tasks/develop_windows/msys2.yml` | `/etc/profile` ハック → `db_home: windows` + `MSYS2_PATH_TYPE=inherit` |
| `tasks/develop_windows/fish.yml` | **新規** fisher + bass + config.fish/functions symlink |
| `tasks/develop_windows/cargo.yml` | **新規** GNU toolchainでcargo install |
| `develop_windows.yml` | cargo, fish タスク import追加 |
| `inventories/.../vars.yml` | `.profile` symlink、python、zoxide、cargo packages追加 |
| `inventories/.../hosts` | `172.21.160.1` 追加 |

## Test plan
- [x] `ansible-playbook --tags msys2,fish,symlink,cargo` 全タスク成功確認
- [x] MSYS2 fishで `uv`, `mcfly`, `zoxide`, `starship` 動作確認
- [x] Windows Terminal にMSYS2プロファイル表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)