### PR TITLE
feat: add Raycast and Input Source Pro to brew cask

### DIFF
--- a/ansible/roles/brew/defaults/main.yml
+++ b/ansible/roles/brew/defaults/main.yml
@@ -132,5 +132,6 @@ brew:
     - shottr
     - ollama-app
     - raycast
+    - input-source-pro
 
 brew_extra_packages: []

--- a/ansible/roles/brew/defaults/main.yml
+++ b/ansible/roles/brew/defaults/main.yml
@@ -131,5 +131,6 @@ brew:
     - deskflow
     - shottr
     - ollama-app
+    - raycast
 
 brew_extra_packages: []


### PR DESCRIPTION
## Summary
- Raycast を brew cask パッケージに追加
- Input Source Pro を brew cask パッケージに追加

## Test plan
- [ ] `ansible-lint .` でエラーがないことを確認
- [ ] `brew install --cask raycast input-source-pro` が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)