### PR TITLE
fix: remove broken symlink refs

### DIFF
--- a/ansible/inventories/develop_macOS/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_macOS/group_vars/all/vars.yml
@@ -122,7 +122,6 @@ develop_configuration:
   ssh_passphrase: "{{ vault_develop_configuration.vault_ssh_passphrase }}"
   directories:
     - ~/.config/fish/
-    - ~/.config/mcfly/
     - ~/.local/bin/
     - ~/workspace/repositories
     - ~/.claude/
@@ -150,8 +149,6 @@ develop_configuration:
       dest: ~/.latexmkrc
     - src: ~/.config/romira-s-config/starship/starship.toml
       dest: ~/.config/starship.toml
-    - src: ~/.config/romira-s-config/mcfly/mcfly.fish
-      dest: ~/.config/mcfly/mcfly.fish
     - src: ~/.config/romira-s-config/ai-config/CLAUDE.md
       dest: ~/.claude/CLAUDE.md
     - src: ~/.config/romira-s-config/ai-config/CLAUDE.md

--- a/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
@@ -46,7 +46,6 @@ develop_configuration:
   ssh_passphrase: "{{ vault_develop_configuration.vault_ssh_passphrase }}"
   directories:
     - ~/.config/fish/
-    - ~/.config/mcfly/
     - ~/.local/bin/
     - ~/workspace/repositories
     - ~/.claude/
@@ -64,8 +63,6 @@ develop_configuration:
       dest: ~/.zshrc
     - src: ~/.config/romira-s-config/zsh/.zpreztorc
       dest: ~/.zpreztorc
-    - src: ~/.config/romira-s-config/git/.bashrc
-      dest: ~/.bashrc
     - src: ~/.config/romira-s-config/vim/.vim
       dest: ~/.vim
     - src: ~/.config/romira-s-config/vim/.vimrc
@@ -74,12 +71,8 @@ develop_configuration:
       dest: ~/.tmux.conf
     - src: ~/.config/romira-s-config/latex/.latexmkrc
       dest: ~/.latexmkrc
-    - src: ~/.config/romira-s-config/zsh/.git-prompt.sh
-      dest: ~/.git-prompt.sh
     - src: ~/.config/romira-s-config/starship/starship.toml
       dest: ~/.config/starship.toml
-    - src: ~/.config/romira-s-config/mcfly/mcfly.fish
-      dest: ~/.config/mcfly/mcfly.fish
     - src: ~/.config/romira-s-config/ai-config/CLAUDE.md
       dest: ~/.claude/CLAUDE.md
     - src: ~/.config/romira-s-config/ai-config/CLAUDE.md

--- a/ansible/molecule/develop_ubuntu_incus/verify.yml
+++ b/ansible/molecule/develop_ubuntu_incus/verify.yml
@@ -145,7 +145,6 @@
       register: dir_check
       loop:
         - "{{ romira_home }}/.config/fish"
-        - "{{ romira_home }}/.config/mcfly"
         - "{{ romira_home }}/.local/bin"
         - "{{ romira_home }}/workspace/repositories"
 


### PR DESCRIPTION
## Summary
- Ansible vars から存在しないファイルへの壊れた symlink 参照を削除
  - `git/.bashrc` (bash/ ディレクトリ削除に伴い不要)
  - `mcfly/mcfly.fish` (ディレクトリ未存在、mcfly init は動的生成)
  - `zsh/.git-prompt.sh` (zprezto + starship で代替済み)
- molecule verify からも mcfly ディレクトリチェックを削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)