### PR TITLE
feat: add AutoHotkey to Windows chocolatey packages

### DIFF
--- a/ansible/inventories/develop_windows/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_windows/group_vars/all/vars.yml
@@ -33,6 +33,7 @@ chocolatey:
     - crystaldiskinfo
     - crystaldiskmark
     - powertoys
+    - autohotkey
     - figma
     - bitwarden
     - rufus


### PR DESCRIPTION
## Summary
- Windows環境のChocolateyパッケージリストにAutoHotkeyを追加

## Test plan
- [x] ansible-lint パス済み
- [x] Windows環境で `choco install autohotkey` によるインストール確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)