### PR TITLE
feat: add .gitconfig.local and ssh-agent setup for Windows

### DIFF
--- a/ansible/develop_windows.yml
+++ b/ansible/develop_windows.yml
@@ -20,6 +20,11 @@
         - develop_configuration
         - symlink
 
+    - import_tasks: tasks/develop_windows/git.yml
+      tags:
+        - develop_configuration
+        - git
+
     - import_tasks: tasks/develop_windows/ssh.yml
       tags:
         - develop_configuration

--- a/ansible/tasks/develop_windows/git.yml
+++ b/ansible/tasks/develop_windows/git.yml
@@ -1,0 +1,11 @@
+---
+- name: Deploy .gitconfig.local for Windows OpenSSH
+  ansible.windows.win_template:
+    src: templates/develop_windows/gitconfig.local.j2
+    dest: "{{ ansible_env.USERPROFILE }}\\.gitconfig.local"
+
+- name: Enable ssh-agent service
+  ansible.windows.win_service:
+    name: ssh-agent
+    start_mode: auto
+    state: started

--- a/ansible/templates/develop_windows/gitconfig.local.j2
+++ b/ansible/templates/develop_windows/gitconfig.local.j2
@@ -1,0 +1,2 @@
+[core]
+      sshCommand = C:/Windows/System32/OpenSSH/ssh.exe


### PR DESCRIPTION
## Summary
- Windows環境向けに `~/.gitconfig.local` をテンプレートで配置（`core.sshCommand` で Windows OpenSSH を指定）
- ssh-agent サービス（OpenSSH Authentication Agent）の自動起動・起動を管理
- `develop_windows.yml` の Play 2 に `git.yml` タスクを追加（symlink後、ssh前）

## Test plan
- [ ] `ansible-playbook --check --diff` で dry-run 確認
- [ ] Windows ホストで `.gitconfig.local` が正しく配置されること
- [ ] ssh-agent サービスが自動起動に設定されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)