### PR TITLE
revert: remove skim from Windows scoop packages

### DIFF
--- a/ansible/inventories/develop_windows/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_windows/group_vars/all/vars.yml
@@ -96,7 +96,6 @@ scoop:
     - eza
     - jq
     - fzf
-    - skim
 winget:
   package:
     - BlueStack.BlueStacks


### PR DESCRIPTION
## Summary
- skim (sk) は Windows を公式サポートしていないため、PR #17 を revert

## Test plan
- [ ] vars.yml から skim が除去されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)