### PR TITLE
fix: suppress ansible-lint template-error for keyboard shortcuts task

### DIFF
--- a/ansible/tasks/develop_macOS/macos_defaults.yml
+++ b/ansible/tasks/develop_macOS/macos_defaults.yml
@@ -303,7 +303,7 @@
 
 # Keyboard Shortcuts
 # キーボードショートカットを設定する (要ログアウト/ログインで反映)
-- name: "Keyboard Shortcuts: Configure {{ item.name }}"
+- name: "Keyboard Shortcuts: Configure {{ item.name }}"  # noqa: template-error
   ansible.builtin.command:
     argv:
       - defaults


### PR DESCRIPTION
## Summary
- キーボードショートカット設定タスクの `{{ item.name }}` に対する ansible-lint の template-error 警告を `# noqa: template-error` で抑制

## Test plan
- [x] `ansible-lint` でテンプレートエラーが出ないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)