### PR TITLE
feat: add topgrade config symlink

### DIFF
--- a/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_ubuntu/group_vars/all/vars.yml
@@ -83,6 +83,8 @@ develop_configuration:
       dest: ~/.config/opencode/AGENTS.md
     - src: ~/.config/romira-s-config/ai-config/settings.json
       dest: ~/.claude/settings.json
+    - src: ~/.config/romira-s-config/topgrade/topgrade.toml
+      dest: ~/.config/topgrade.toml
   wsl_symbolic_links:
     - src: /mnt/c/Windows/System32/clip.exe
       dest: ~/.local/bin/clip


### PR DESCRIPTION
## Summary
- topgrade設定ファイルのシンボリックリンクをUbuntu inventoryに追加
- `~/.config/romira-s-config/topgrade/topgrade.toml` → `~/.config/topgrade.toml`

## Test plan
- [ ] `ansible-playbook develop_ubuntu.yml` でシンボリックリンクが正しく作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)