### PR TITLE
feat: Windows環境にAI設定のシンボリックリンクを追加

### DIFF
--- a/ansible/inventories/develop_windows/group_vars/all/vars.yml
+++ b/ansible/inventories/develop_windows/group_vars/all/vars.yml
@@ -123,6 +123,18 @@ develop_configuration:
       dest: C:\Users\{{ ansible_user }}\.wslconfig
     - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\shell\.profile
       dest: C:\Users\{{ ansible_user }}\.profile
+    - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\ai-config\CLAUDE.md
+      dest: C:\Users\{{ ansible_user }}\.claude\CLAUDE.md
+    - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\ai-config\CLAUDE.md
+      dest: C:\Users\{{ ansible_user }}\.codex\AGENTS.md
+    - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\ai-config\CLAUDE.md
+      dest: C:\Users\{{ ansible_user }}\.gemini\GEMINI.md
+    - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\ai-config\CLAUDE.md
+      dest: C:\Users\{{ ansible_user }}\.config\opencode\AGENTS.md
+    - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\ai-config\settings.json
+      dest: C:\Users\{{ ansible_user }}\.claude\settings.json
+    - src: C:\Users\{{ ansible_user }}\.config\romira-s-config\starship\starship.toml
+      dest: C:\Users\{{ ansible_user }}\.config\starship.toml
   directory_symbolic_links:
     - src: D:\Users\{{ ansible_user }}\workspace\repositories
       dest: C:\Users\{{ ansible_user }}\workspace\repositories
@@ -151,6 +163,22 @@ fonts:
       dest: C:\Users\{{ ansible_user }}\.tmp\fonts\Myrica.zip
     - url: https://github.com/tomokuni/Myrica/raw/master/product/MyricaM.zip
       dest: C:\Users\{{ ansible_user }}\.tmp\fonts\MyricaM.zip
+ai_config_dirs:
+  - C:\Users\{{ ansible_user }}\.claude
+  - C:\Users\{{ ansible_user }}\.codex
+  - C:\Users\{{ ansible_user }}\.gemini
+  - C:\Users\{{ ansible_user }}\.config\opencode
+ai_skills:
+  src: C:\Users\{{ ansible_user }}\.config\romira-s-config\ai-config\skills
+  destinations:
+    - C:\Users\{{ ansible_user }}\.claude\skills
+    - C:\Users\{{ ansible_user }}\.codex\skills
+    - C:\Users\{{ ansible_user }}\.gemini\skills
+    - C:\Users\{{ ansible_user }}\.config\opencode\skills
+ai_rules:
+  src: C:\Users\{{ ansible_user }}\.config\romira-s-config\ai-config\rules
+  destinations:
+    - C:\Users\{{ ansible_user }}\.claude\rules
 cargo:
   packages:
     - mcfly

--- a/ansible/tasks/develop_windows/symlink.yml
+++ b/ansible/tasks/develop_windows/symlink.yml
@@ -1,4 +1,11 @@
 ---
+- name: Ensure AI config directories exist
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: directory
+  loop: "{{ ai_config_dirs }}"
+  when: ai_config_dirs is defined
+
 - name: Create symbolic links
   ansible.windows.win_shell: "cmd /c mklink {{ item.dest }} {{ item.src }}"
   failed_when: "'already exists' not in create_symbolic_link.stderr and create_symbolic_link.rc != 0"
@@ -27,3 +34,63 @@
   changed_when: create_hard_links.rc == 0
   register: create_hard_links
   loop: "{{ develop_configuration.hard_links }}"
+
+- name: Ensure AI skills destination directories exist
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: directory
+  loop: "{{ ai_skills.destinations }}"
+  when: ai_skills is defined
+
+- name: Check if AI skills source directory exists
+  ansible.windows.win_stat:
+    path: "{{ ai_skills.src }}"
+  register: ai_skills_src_stat
+  when: ai_skills is defined
+
+- name: Find AI skill entries
+  ansible.windows.win_find:
+    paths: "{{ ai_skills.src }}"
+    file_type: directory
+  register: ai_skill_entries
+  when: ai_skills is defined and ai_skills_src_stat.stat.exists
+
+- name: Create symbolic links for AI skills
+  ansible.windows.win_shell: "cmd /c mklink /D \"{{ item.1 }}\\{{ item.0.filename }}\" \"{{ item.0.path }}\""
+  failed_when: "'already exists' not in create_ai_skill_link.stderr and create_ai_skill_link.rc != 0"
+  changed_when: create_ai_skill_link.rc == 0
+  register: create_ai_skill_link
+  loop: "{{ ai_skill_entries.files | product(ai_skills.destinations) | list }}"
+  loop_control:
+    label: "{{ item.1 }}\\{{ item.0.filename }}"
+  when: ai_skills is defined and ai_skill_entries.files is defined
+
+- name: Ensure AI rules destination directories exist
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: directory
+  loop: "{{ ai_rules.destinations }}"
+  when: ai_rules is defined
+
+- name: Check if AI rules source directory exists
+  ansible.windows.win_stat:
+    path: "{{ ai_rules.src }}"
+  register: ai_rules_src_stat
+  when: ai_rules is defined
+
+- name: Find AI rule entries
+  ansible.windows.win_find:
+    paths: "{{ ai_rules.src }}"
+    file_type: file
+  register: ai_rule_entries
+  when: ai_rules is defined and ai_rules_src_stat.stat.exists
+
+- name: Create symbolic links for AI rules
+  ansible.windows.win_shell: "cmd /c mklink \"{{ item.1 }}\\{{ item.0.filename }}\" \"{{ item.0.path }}\""
+  failed_when: "'already exists' not in create_ai_rule_link.stderr and create_ai_rule_link.rc != 0"
+  changed_when: create_ai_rule_link.rc == 0
+  register: create_ai_rule_link
+  loop: "{{ ai_rule_entries.files | product(ai_rules.destinations) | list }}"
+  loop_control:
+    label: "{{ item.1 }}\\{{ item.0.filename }}"
+  when: ai_rules is defined and ai_rule_entries.files is defined


### PR DESCRIPTION
## Summary
- develop_windowsインベントリにClaude Code/Codex/Gemini/OpenCodeの設定ファイル（CLAUDE.md, settings.json, starship.toml）のシンボリックリンク定義を追加
- AI skills/rulesディレクトリのシンボリックリンク定義を追加
- symlink.ymlにディレクトリ作成・リンク作成タスクを実装

## Test plan
- [ ] `ansible-lint .` パス確認済み
- [ ] `ansible-playbook --check --diff` で dry-run 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)