### PR TITLE
fix(ansible): switch terraform to hashicorp/tap formula

### DIFF
--- a/ansible/roles/brew/defaults/main.yml
+++ b/ansible/roles/brew/defaults/main.yml
@@ -15,7 +15,7 @@ brew:
     - gradle
     - java
     - openjdk
-    - terraform
+    - hashicorp/tap/terraform
     - sqlite
     - oci-cli
     - go


### PR DESCRIPTION
## Summary
- `brew` role の `terraform` パッケージを `hashicorp/tap/terraform` に変更
- HashiCorp の BUSL ライセンス変更を受けて homebrew-core から terraform が削除されたため、`ansible-playbook` 実行時に `Error: No available formula with the name "terraform"` で失敗していた
- `community.general.homebrew` モジュールは `tap/formula` 形式を受け付け、必要なら auto-tap される

## Test plan
- [x] `brew install hashicorp/tap/terraform` で v1.15.2 のインストールを手動確認
- [x] `ansible-lint .` パス
- [ ] `ansible-playbook --check --diff -i inventories/develop_macOS/hosts develop_macOS.yml --limit 127.0.0.1 --connection local` で brew タスクが通ること（実機で確認）