### PR TITLE
hasu music quiz backend の本番設定を追加

### DIFF
--- a/ansible/inventories/oci-tokyo-ampere/files/app_layout/hasu-music-quiz-backend/systemd_env
+++ b/ansible/inventories/oci-tokyo-ampere/files/app_layout/hasu-music-quiz-backend/systemd_env
@@ -1,0 +1,4 @@
+BIND_ADDR=127.0.0.1:26128
+VALKEY_URL=redis://127.0.0.1:51032/1
+VALKEY_KEY_PREFIX=hasu-music-quiz:
+FRONTEND_ORIGINS=https://hasu-music-quiz.aileafmura.com

--- a/ansible/inventories/oci-tokyo-ampere/files/nginx/sites-available/api.hasu-music-quiz.aileafmura.com.conf
+++ b/ansible/inventories/oci-tokyo-ampere/files/nginx/sites-available/api.hasu-music-quiz.aileafmura.com.conf
@@ -23,26 +23,13 @@ server {
         proxy_send_timeout 86400s;
     }
 
-    location = /health {
-        proxy_pass http://127.0.0.1:26128;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location = /api/info {
-        proxy_pass http://127.0.0.1:26128;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     location / {
-        return 404;
+        proxy_pass http://127.0.0.1:26128;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     listen 443 ssl; # managed by Certbot

--- a/ansible/inventories/oci-tokyo-ampere/files/nginx/sites-available/api.hasu-music-quiz.aileafmura.com.conf
+++ b/ansible/inventories/oci-tokyo-ampere/files/nginx/sites-available/api.hasu-music-quiz.aileafmura.com.conf
@@ -1,0 +1,63 @@
+map $http_upgrade $hasu_music_quiz_connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    server_name api.hasu-music-quiz.aileafmura.com;
+
+    client_max_body_size 1m;
+
+    location = /ws {
+        proxy_pass http://127.0.0.1:26128;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $hasu_music_quiz_connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+
+    location = /health {
+        proxy_pass http://127.0.0.1:26128;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /api/info {
+        proxy_pass http://127.0.0.1:26128;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        return 404;
+    }
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/api.hasu-music-quiz.aileafmura.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/api.hasu-music-quiz.aileafmura.com/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+server {
+    if ($host = api.hasu-music-quiz.aileafmura.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+    listen 80;
+    server_name api.hasu-music-quiz.aileafmura.com;
+    return 404; # managed by Certbot
+}

--- a/ansible/inventories/oci-tokyo-ampere/files/systemd/hasu-music-quiz-backend.service
+++ b/ansible/inventories/oci-tokyo-ampere/files/systemd/hasu-music-quiz-backend.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Hasu Music Quiz backend
+BindsTo=valkey-server.service
+After=network.target valkey-server.service
+
+[Service]
+EnvironmentFile=/usr/local/hasu-music-quiz-backend/systemd_env
+WorkingDirectory=/usr/local/hasu-music-quiz-backend
+ExecStart=/usr/local/hasu-music-quiz-backend/bin/hasu-music-quiz-backend
+User=ubuntu
+Group=ubuntu
+Restart=always
+RestartSec=10s
+Type=simple
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/inventories/oci-tokyo-ampere/files/systemd/hasu-music-quiz-backend.service
+++ b/ansible/inventories/oci-tokyo-ampere/files/systemd/hasu-music-quiz-backend.service
@@ -4,9 +4,9 @@ BindsTo=valkey-server.service
 After=network.target valkey-server.service
 
 [Service]
-EnvironmentFile=/usr/local/hasu-music-quiz-backend/systemd_env
-WorkingDirectory=/usr/local/hasu-music-quiz-backend
-ExecStart=/usr/local/hasu-music-quiz-backend/bin/hasu-music-quiz-backend
+EnvironmentFile=/opt/hasu-music-quiz-backend/systemd_env
+WorkingDirectory=/opt/hasu-music-quiz-backend
+ExecStart=/opt/hasu-music-quiz-backend/bin/hasu-music-quiz-backend
 User=ubuntu
 Group=ubuntu
 Restart=always

--- a/ansible/inventories/oci-tokyo-ampere/group_vars/all/vars.yml
+++ b/ansible/inventories/oci-tokyo-ampere/group_vars/all/vars.yml
@@ -93,18 +93,21 @@ docker:
 
 app_layouts:
   - name: hasu-music-quiz-backend
-    path: /usr/local/hasu-music-quiz-backend
-    owner: ubuntu
-    group: ubuntu
+    path: /opt/hasu-music-quiz-backend
+    owner: root
+    group: root
     mode: "0755"
     directories:
       - path: bin
-        owner: ubuntu
-        group: ubuntu
+        owner: root
+        group: root
         mode: "0755"
     required_files:
       - path: systemd_env
-        managed: false
+        managed: true
+        owner: root
+        group: root
+        mode: "0600"
       - path: bin/hasu-music-quiz-backend
         managed: false
 

--- a/ansible/inventories/oci-tokyo-ampere/group_vars/all/vars.yml
+++ b/ansible/inventories/oci-tokyo-ampere/group_vars/all/vars.yml
@@ -46,12 +46,15 @@ nginx:
     - mime.conf
     - newrelic.conf
   site_files:
+    - api.hasu-music-quiz.aileafmura.com.conf
     - blog.romira.dev.conf
     - dev-site.romira.dev.conf
     - obsidian-sync.romira.dev
     - opencode.romira.dev.conf
     - vaultwarden.romira.dev.conf
   enabled_sites:
+    - name: api.hasu-music-quiz.aileafmura.com.conf
+      src: ../sites-available/api.hasu-music-quiz.aileafmura.com.conf
     - name: blog.romira.dev.conf
       src: ../sites-available/blog.romira.dev.conf
     - name: dev-site.romira.dev.conf
@@ -78,6 +81,7 @@ postgresql:
 systemd_units:
   - name: blog-romira-dev-leptos.service
   - name: discord-bot-mgpf.service
+  - name: hasu-music-quiz-backend.service
   - name: vaultwarden.service
 
 # Docker data-root migration settings
@@ -88,6 +92,22 @@ docker:
   remove_old_data: false
 
 app_layouts:
+  - name: hasu-music-quiz-backend
+    path: /usr/local/hasu-music-quiz-backend
+    owner: ubuntu
+    group: ubuntu
+    mode: "0755"
+    directories:
+      - path: bin
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+    required_files:
+      - path: systemd_env
+        managed: false
+      - path: bin/hasu-music-quiz-backend
+        managed: false
+
   - name: blog-romira-dev-leptos
     path: /usr/local/blog-romira-dev-leptos
     owner: ubuntu

--- a/ansible/roles/app_layout/README.md
+++ b/ansible/roles/app_layout/README.md
@@ -4,3 +4,4 @@ Manage application runtime directories and verify externally deployed files exis
 
 This role intentionally does not build, deploy, pull, or update application code or Docker images.
 Files marked as `managed: false` are checked with `stat`/`assert` only.
+Files marked as `managed: true` are copied from `files/app_layout/<app-name>/<path>` before the check.

--- a/ansible/roles/app_layout/defaults/main.yml
+++ b/ansible/roles/app_layout/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 app_layout_enforce_required_files: true
+app_layout_src_dir: "{{ playbook_dir }}/inventories/{{ target_inventory }}/files/app_layout"
 app_layouts: []

--- a/ansible/roles/app_layout/tasks/main.yml
+++ b/ansible/roles/app_layout/tasks/main.yml
@@ -29,6 +29,22 @@
     - app-layout
     - configuration
 
+- name: Copy managed app required files
+  ansible.builtin.copy:
+    src: "{{ app_layout_src_dir }}/{{ item.1.src | default(item.0.name ~ '/' ~ item.1.path) }}"
+    dest: "{{ item.0.path }}/{{ item.1.path }}"
+    owner: "{{ item.1.owner | default(item.0.owner | default('root')) }}"
+    group: "{{ item.1.group | default(item.0.group | default('root')) }}"
+    mode: "{{ item.1.mode | default('0644') }}"
+  become: true
+  loop: "{{ app_layouts | subelements('required_files', skip_missing=True) }}"
+  loop_control:
+    label: "{{ item.0.name }}:{{ item.1.path }}"
+  when: item.1.managed | default(false) | bool
+  tags:
+    - app-layout
+    - configuration
+
 - name: Stat app required files
   ansible.builtin.stat:
     path: "{{ item.0.path }}/{{ item.1.path }}"

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -70,6 +70,7 @@
     src: "{{ item.src }}"
     dest: "/etc/nginx/sites-enabled/{{ item.name }}"
     state: link
+    force: "{{ ansible_check_mode }}"
     owner: root
     group: root
   become: true

--- a/ansible/roles/systemd_units/tasks/main.yml
+++ b/ansible/roles/systemd_units/tasks/main.yml
@@ -13,6 +13,14 @@
     - systemd-units
     - configuration
 
+- name: Gather systemd service facts in check mode
+  ansible.builtin.service_facts:
+  become: true
+  when: ansible_check_mode
+  tags:
+    - systemd-units
+    - systemd
+
 - name: Ensure systemd units are enabled and started
   ansible.builtin.systemd:
     name: "{{ item.name }}"
@@ -21,6 +29,7 @@
     daemon_reload: true
   become: true
   loop: "{{ systemd_units }}"
+  when: not ansible_check_mode or item.name in ansible_facts.services
   tags:
     - systemd-units
     - systemd


### PR DESCRIPTION
## Summary
- api.hasu-music-quiz.aileafmura.com の nginx WebSocket proxy 設定を追加
- hasu-music-quiz-backend の systemd unit と app_layout を追加
- Ansible check mode で新規 nginx site / systemd unit を検証しやすいよう role を調整

## Test Plan
- ansible-lint .
- ansible-playbook --check --diff -i inventories/oci-tokyo-ampere/hosts oci-tokyo-ampere.yml
- 本番で /health, WebSocket 101, Origin 403, systemd active を確認済み